### PR TITLE
chore: update cargo.lock version for hyprland-activewindow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "hyprland-activewindow"
-version = "1.0.3-beta"
+version = "1.0.3"
 dependencies = [
  "flexi_logger",
  "hyprland",


### PR DESCRIPTION
Minor fix to update out of date version of `hyprland-actiwindow` in `Cargo.lock` and the errror

`hyprland-activewindow> error: the lock file /build/source/Cargo.lock needs to be updated but --frozen was passed to prevent this`

Fixes #20.
